### PR TITLE
Add an option to put users into a team upon joining the Organization

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,8 +25,11 @@ const jwt = require('jsonwebtoken')
 const bodyParser = require('koa-bodyparser')
 const server = new Koa()
 const router = require('koa-router')()
+const session = require('koa-session')
+
 server.use(bodyParser())
 server.keys = [process.env.WEBHOOK_SECRET]
+server.use(session(server))
 
 // Bring in that serverless-http magic
 const serverless = require('serverless-http')
@@ -100,7 +103,8 @@ router.get('/good-bye', ctx => {
 router.use(async (ctx, next) => {
   const token = ctx.cookies.get('session')
   if (!token) {
-    ctx.state.redirect = '/'
+    ctx.session = {}
+    ctx.session.redirect = ctx.originalUrl
     return ctx.redirect('/github/login')
   }
   const github = await robot.auth()

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -31,7 +31,7 @@ router.get('/github/callback', async ctx => {
 
   if (tokenRes.statusCode === 200) {
     ctx.cookies.set('session', tokenRes.body.access_token)
-    ctx.redirect(ctx.state.redirect || '/')
+    ctx.redirect(ctx.session.redirect || '/')
   } else {
     ctx.status(500)
     ctx.body = 'Invalid code'

--- a/views/new.hbs
+++ b/views/new.hbs
@@ -20,12 +20,25 @@
         </p>
       </label>
 
-      <label class="d-block">
+      <label class="d-block mb-2">
         <input name="role" type="radio" value="admin">
         Owner
         <p class="note">
           Owners have full administrative rights to the organization and have complete access to all
           repositories and teams.
+        </p>
+      </label>
+
+      <label class="d-block mb-2">
+        Team
+        <select name="team" class="form-select ml-1" style="width:150px;">
+          <option selected value="">None</option>
+          {{#each teams}}
+            <option value="{{id}}">{{name}}</option>
+          {{/each}}
+        </select>
+        <p class="note">
+          Add the user to a team when joining.
         </p>
       </label>
     </div>


### PR DESCRIPTION
Simple option that queries the Org for a list of teams and adds that as an option in the generated URL. Using this for the [GitHub-JenkinsDay](https://github.com/GitHub-JenkinsDay) workshop, which only has a few teams in it, so I haven't done any testing to see how this works with nested teams, and it's not paginating through the list of teams, so right now it's only going to show the first 30 teams in an Org.